### PR TITLE
install-1.0.0.php

### DIFF
--- a/code/local/Evozon/Blog/sql/evozon_blog_setup/install-1.0.0.php
+++ b/code/local/Evozon/Blog/sql/evozon_blog_setup/install-1.0.0.php
@@ -661,10 +661,10 @@ $table = $this->getConnection()
         ), 'Tag ID'
     )
     ->addColumn(
-        'store_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+        'store_id', Varien_Db_Ddl_Table::TYPE_SMALLINT, null, array(
         'nullable' => false,
         'default' => '0',
-        ), 'Position'
+        ), 'Store ID'
     )
     ->addIndex(
         $installer->getIdxName(


### PR DESCRIPTION
'store_id' was TYPE_INTEGER and needs to be TYPE_SMALLINT otherwise the installer fails on Magento 1.9.x,